### PR TITLE
luci: add domainsExcluded option

### DIFF
--- a/luci-app-passwall2/Makefile
+++ b/luci-app-passwall2/Makefile
@@ -117,6 +117,7 @@ endef
 define Package/$(PKG_NAME)/conffiles
 /etc/config/passwall2
 /etc/config/passwall2_server
+/usr/share/passwall2/domains_excluded
 endef
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
@@ -37,6 +37,7 @@ local uci = api.uci
 local sys = api.sys
 local jsonc = api.jsonc
 local appname = api.appname
+local fs = api.fs
 local dns = nil
 local fakedns = nil
 local inbounds = {}
@@ -50,6 +51,21 @@ local function get_new_port()
         new_port = tonumber(sys.exec(string.format("echo -n $(/usr/share/%s/app.sh get_new_port auto tcp)", appname)))
     end
     return new_port
+end
+
+local function get_domain_excluded()
+    local path = string.format("/usr/share/%s/domains_excluded", appname)
+    local content = fs.readfile(path)
+    if not content then return nil end
+    local hosts = {}
+    string.gsub(content, '[^' .. "\n" .. ']+', function(w)
+        local s = w:gsub("^%s*(.-)%s*$", "%1") -- Trim
+        if s == "" then return end
+        if s:find("#") and s:find("#") == 1 then return end
+        if not s:find("#") or s:find("#") ~= 1 then table.insert(hosts, s) end
+    end)
+    if #hosts == 0 then hosts = nil end
+    return hosts
 end
 
 function gen_outbound(node, tag, proxy_table)
@@ -276,14 +292,14 @@ if true then
             protocol = "dokodemo-door",
             settings = {network = "tcp", followRedirect = true},
             streamSettings = {sockopt = {tproxy = tcp_proxy_way}},
-            sniffing = {enabled = sniffing and true or false, destOverride = {"http", "tls", (dns_fakedns) and "fakedns"}, metadataOnly = false, routeOnly = route_only and true or nil}
+            sniffing = {enabled = sniffing and true or false, destOverride = {"http", "tls", (dns_fakedns) and "fakedns"}, metadataOnly = false, routeOnly = route_only and true or nil, domainsExcluded = (sniffing and not route_only) and get_domain_excluded() or nil}
         })
         table.insert(inbounds, {
             port = tonumber(redir_port),
             protocol = "dokodemo-door",
             settings = {network = "udp", followRedirect = true},
             streamSettings = {sockopt = {tproxy = "tproxy"}},
-            sniffing = {enabled = sniffing and true or false, destOverride = {"http", "tls", (dns_fakedns) and "fakedns"}, metadataOnly = false, routeOnly = route_only and true or nil}
+            sniffing = {enabled = sniffing and true or false, destOverride = {"http", "tls", (dns_fakedns) and "fakedns"}, metadataOnly = false, routeOnly = route_only and true or nil, domainsExcluded = (sniffing and not route_only) and get_domain_excluded() or nil}
         })
     end
 

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
@@ -1,5 +1,6 @@
 local api = require "luci.model.cbi.passwall2.api.api"
 local appname = api.appname
+local fs = api.fs
 
 m = Map(appname)
 
@@ -108,5 +109,14 @@ o.rmempty = false
 o = s:option(Flag, "route_only", translate("Sniffing Route Only (Xray)"), translate("When enabled, the server not will resolve the domain name again."))
 o.default = 0
 o:depends("sniffing", true)
+
+local domains_excluded = string.format("/usr/share/%s/domains_excluded", appname)
+o = s:option(TextValue, "no_sniffing_hosts", translate("No Sniffing Lists"), translate("Hosts added into No Sniffing Lists will not resolve again on server (Xray only)."))
+o.rows = 15
+o.wrap = "off"
+o.cfgvalue = function(self, section) return fs.readfile(domains_excluded) or "" end
+o.write = function(self, section, value) fs.writefile(domains_excluded, value:gsub("\r\n", "\n")) end
+o.remove = function(self, section, value) fs.writefile(domains_excluded, "") end
+o:depends({sniffing = true, route_only = false})
 
 return m

--- a/luci-app-passwall2/po/zh-cn/passwall2.po
+++ b/luci-app-passwall2/po/zh-cn/passwall2.po
@@ -1254,3 +1254,9 @@ msgstr "无子连接时的健康检查"
 
 msgid "Initial Windows Size"
 msgstr "初始窗口大小"
+
+msgid "No Sniffing Lists"
+msgstr "不进行流量嗅探的域名列表"
+
+msgid "Hosts added into No Sniffing Lists will not resolve again on server (Xray only)."
+msgstr "加入的域名不会再次在服务器解析（仅适用于Xray）。"

--- a/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
+++ b/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
@@ -1,0 +1,23 @@
+rbsxbxp-mim.vivox.com
+rbsxbxp.www.vivox.com
+rbsxbxp-ws.vivox.com
+rbspsxp.www.vivox.com
+rbspsxp-mim.vivox.com
+rbspsxp-ws.vivox.com
+rbswxp.www.vivox.com
+rbswxp-mim.vivox.com
+disp-rbspsp-5-1.vivox.com
+disp-rbsxbp-5-1.vivox.com
+proxy.rbsxbp.vivox.com
+proxy.rbspsp.vivox.com
+proxy.rbswp.vivox.com
+rbswp.vivox.com
+rbsxbp.vivox.com
+rbspsp.vivox.com
+rbspsp.www.vivox.com
+rbswp.www.vivox.com
+rbsxbp.www.vivox.com
+rbsxbxp.vivox.com
+rbspsxp.vivox.com
+rbswxp.vivox.com
+Mijia Cloud


### PR DESCRIPTION
添加domainsExcluded选项配置。

默认配置文件中的配置一部分来自于https://github.com/XTLS/Xray-core/discussions/364#discussion-3268358 （彩虹六号语音，未测试）。

最后一行Mijia Cloud为我本地测试环境下的一个米家智能插座，抓包分析结果如下：
![image](https://user-images.githubusercontent.com/4453837/158039566-3c1411fe-b1d9-4626-bdd4-6d326d3d4351.png)

sni不写域名 ~~小米您真行~~

本地测试结果：米家插座正常联网。其他功能无异常
