### PR TITLE
luci: add support for shadowsocks-rust AEAD-2022 ciphers

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/node_config.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/node_config.lua
@@ -15,7 +15,8 @@ local ss_encrypt_method_list = {
 
 local ss_rust_encrypt_method_list = {
     "plain", "none",
-    "aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305"
+    "aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305",
+    "2022-blake3-aes-128-gcm", "2022-blake3-aes-256-gcm", "2022-blake3-chacha8-poly1305", "2022-blake3-chacha20-poly1305"
 }
 
 local ssr_encrypt_method_list = {


### PR DESCRIPTION
Wait for shadowsocks-rust 1.15.0 release to support these new ciphers.