### PR TITLE
fix: user custom remote DNS with private IP was route to internet

### DIFF
--- a/luci-app-passwall2/Makefile
+++ b/luci-app-passwall2/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-passwall2
 PKG_VERSION:=1.3
-PKG_RELEASE:=21
+PKG_RELEASE:=22
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_Transparent_Proxy \

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/api/api.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/api/api.lua
@@ -188,15 +188,6 @@ function iprange(val)
     return false
 end
 
-function is_private_ipv4(val)
-    if val then
-        if val:match("^10%.") or val:match("^127%.") or val:match("^192%.168%.") or val:match("^172%.16%.") or val:match("^172%.19%.") or val:match("^169%.245%.") then
-            return true
-        end
-    end
-    return false
-end
-
 function get_domain_from_url(url)
     local domain = string.match(url, "//([^/]+)")
     if domain then

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/api/api.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/api/api.lua
@@ -188,6 +188,15 @@ function iprange(val)
     return false
 end
 
+function is_private_ipv4(val)
+    if val then
+        if val:match("^10%.") or val:match("^127%.") or val:match("^192%.168%.") or val:match("^172%.16%.") or val:match("^172%.19%.") or val:match("^169%.245%.") then
+            return true
+        end
+    end
+    return false
+end
+
 function get_domain_from_url(url)
     local domain = string.match(url, "//([^/]+)")
     if domain then

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
@@ -638,6 +638,18 @@ if remote_dns_server or remote_dns_doh_url or remote_dns_fake then
             _remote_dns_proto = "tcp"
         end
 
+        if api.is_private_ipv4(_remote_dns.address) then
+            table.insert(routing.rules, 1, {
+                type = "field",
+                ip = {
+                    _remote_dns.address
+                },
+                port = _remote_dns.port,
+                network = _remote_dns_proto,
+                outboundTag = "direct"
+            })
+        end
+
         if remote_dns_fake then
             remote_dns_server = "1.1.1.1"
             fakedns = {}

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/api/gen_v2ray.lua
@@ -638,17 +638,13 @@ if remote_dns_server or remote_dns_doh_url or remote_dns_fake then
             _remote_dns_proto = "tcp"
         end
 
-        if api.is_private_ipv4(_remote_dns.address) then
-            table.insert(routing.rules, 1, {
-                type = "field",
-                ip = {
-                    _remote_dns.address
-                },
-                port = _remote_dns.port,
-                network = _remote_dns_proto,
-                outboundTag = "direct"
-            })
-        end
+        table.insert(routing.rules, 1, {
+            type = "field",
+            ip = {
+                "geoip:private"
+            },
+            outboundTag = "direct"
+        })
 
         if remote_dns_fake then
             remote_dns_server = "1.1.1.1"


### PR DESCRIPTION
If use local smartdns server as remote DNS server, IP and port 127.0.0.1:7053, xray log shows that it was route to internet, remote DNS query no response until timeout, and smartdns log do not received any DNS query at all.
![image](https://user-images.githubusercontent.com/30518126/169707184-e7b2fb26-b3f2-447d-bd7d-94764c5ef0b2.png)
