### PR TITLE
Update app.sh

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -741,7 +741,7 @@ boot() {
 }
 
 start() {
-	pgrep -f /tmp/etc/passwall2 > /dev/null 2>&1 && {
+	pgrep -f /tmp/etc/passwall2/bin > /dev/null 2>&1 && {
 		echolog "程序已启动，无需重复启动!"
 		return 0
 	}


### PR DESCRIPTION
发现一个潜在的副作用。 同时开服务器端的时候，有一定概率服务器端passwall2_server可以起来，但是passwall2会报“程序已启动，无需重复启动!”。  可以修改passwall2服务启动顺序，同时取消启动延时，规避。