### PR TITLE
fix tproxy nftable rules problems

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
@@ -216,7 +216,9 @@ load_acl() {
 			[ "$udp_no_redir_ports" = "default" ] && udp_no_redir_ports=$UDP_NO_REDIR_PORTS
 			[ "$tcp_redir_ports" = "default" ] && tcp_redir_ports=$TCP_REDIR_PORTS
 			[ "$udp_redir_ports" = "default" ] && udp_redir_ports=$UDP_REDIR_PORTS
-			
+			[ "$tcp_no_redir_ports" = "1:65535" ] && tcp_proxy_mode="disable"
+			[ "$udp_no_redir_ports" = "1:65535" ] && udp_proxy_mode="disable"
+
 			node_remark=$(config_n_get $NODE remarks)
 			[ -s "${TMP_ACL_PATH}/${sid}/var_node" ] && node=$(cat ${TMP_ACL_PATH}/${sid}/var_node)
 			[ -s "${TMP_ACL_PATH}/${sid}/var_port" ] && redir_port=$(cat ${TMP_ACL_PATH}/${sid}/var_port)
@@ -264,7 +266,7 @@ load_acl() {
 						}
 
 						[ "$tcp_no_redir_ports" != "disable" ] && {
-							nft "add rule inet fw4 $nft_prerouting_chain ${_ipt_source} ip protocol tcp tcp dport {$tcp_no_redir_ports} counter return comment \"$remarks\""
+							nft "add rule inet fw4 $nft_prerouting_chain ${_ipt_source} ip protocol tcp $(factor $tcp_no_redir_ports "tcp dport") counter return comment \"$remarks\""
 							nft "add rule inet fw4 PSW2_MANGLE_V6 comment ${_ipt_source} meta l4proto tcp tcp dport {$tcp_no_redir_ports} counter return comment \"$remarks\""
 							msg2="${msg2}[$?]除${tcp_no_redir_ports}外的"
 						}
@@ -298,8 +300,8 @@ load_acl() {
 						msg2="${msg}使用UDP节点[$node_remark] [$(get_action_chain_name $udp_proxy_mode)]"
 						msg2="${msg2}(TPROXY:${redir_port})代理"
 						[ "$udp_no_redir_ports" != "disable" ] && {
-							nft add rule inet fw4 PSW2_MANGLE meta l4proto udp ${_ipt_source} $(factor $udp_no_redir_ports "udp dport") counter return
-							nft add rule inet fw4 PSW2_MANGLE_V6 meta l4proto udp ${_ipt_source} $(factor $udp_no_redir_ports "udp dport") counter return 2>/dev/null
+							nft "add rule inet fw4 PSW2_MANGLE meta l4proto udp ${_ipt_source} $(factor $udp_no_redir_ports "udp dport") counter return comment \"$remarks\""
+							nft "add rule inet fw4 PSW2_MANGLE_V6 meta l4proto udp ${_ipt_source} $(factor $udp_no_redir_ports "udp dport") counter return comment \"$remarks\"" 2>/dev/null
 							msg2="${msg2}[$?]除${udp_no_redir_ports}外的"
 						}
 						msg2="${msg2}所有端口"


### PR DESCRIPTION
fix #308 

1. fix redundancy rules
config:
![image](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/3b0f781c-25a0-4697-bc6e-f51bc205aaa9)
before modify:
![修改前](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/b3032d30-62ae-4713-b445-c7b3baa3d82a)
![Snipaste_2023-07-28_20-14-09](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/d7eee76a-a9f5-4f4a-9792-6fa1fcea48fb)
after modify:
![修改后](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/0a13afca-c505-4aa8-99aa-ff288b711b26)
![修改后Snipaste_2023-07-28_20-26-50](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/ec426603-08d4-4ce1-abdf-17d0109ece93)

2. fix range ports tcp rules
config:
![image](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/f6665848-1bdb-481f-93c2-c400555930ee)
before modify:
NO rules
after modify:
![修改后Snipaste_2023-07-28_20-41-34](https://github.com/xiaorouji/openwrt-passwall2/assets/32849562/5fd0e915-76cb-4f08-9994-61aa166234e6)
