### PR TITLE
[RFC] [xray] Add packet fragmentation feature

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
@@ -141,6 +141,26 @@ if has_xray then
 	s_xray.anonymous = true
 	s_xray.addremove = false
 
+	o = s_xray:option(Flag, "fragment", translate("Fragment"), translate("TCP fragments, which can deceive the censorship system in some cases, such as bypassing SNI blacklists."))
+	o.default = 0
+	o.rmempty = false
+	
+	o = s_xray:option(ListValue, "fragment_packets", translate("Fragment Packets"), translate(" \"1-3\" is for segmentation at TCP layer, applying to the beginning 1 to 3 data writes by the client. \"tlshello\" is for TLS client hello packet fragmentation."))
+	o.default = "tlshello"
+	o:value("1-3", "1-3")
+	o:value("tlshello", "tlshello")
+	o:depends("fragment", true)
+	
+	o = s_xray:option(Value, "fragment_length", translate("Fragment Length"), translate("Fragmented packet length (byte)"))
+	o.default = "10-20"
+	o.rmempty = false
+	o:depends("fragment", true)
+	
+	o = s_xray:option(Value, "fragment_interval", translate("Fragment Interval"), translate("Fragmentation interval (ms)"))
+	o.default = "10-20"
+	o.rmempty = false
+	o:depends("fragment", true)
+	
 	o = s_xray:option(Flag, "sniffing", translate("Sniffing"), translate("When using the shunt, must be enabled, otherwise the shunt will invalid."))
 	o.default = 1
 	o.rmempty = false

--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -127,7 +127,10 @@ function gen_outbound(flag, node, tag, proxy_table)
 			-- 底层传输配置
 			streamSettings = (node.streamSettings or node.protocol == "vmess" or node.protocol == "vless" or node.protocol == "socks" or node.protocol == "shadowsocks" or node.protocol == "trojan") and {
 				sockopt = {
-					mark = 255
+					mark = 255,
+					dialerProxy = "fragment",
+					tcpKeepAliveIdle = 100,
+					tcpNoDelay = true
 				},
 				network = node.transport,
 				security = node.stream_security,

--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -1338,6 +1338,27 @@ function gen_config(var)
 				-- }
 			}
 		}
+		
+		if xray_settings.fragment and true then
+			table.insert(outbounds, {
+				protocol = "freedom",
+				tag = "fragment",
+				settings = {
+					domainStrategy = (direct_dns_query_strategy and direct_dns_query_strategy ~= "") and direct_dns_query_strategy or "UseIP",
+					fragments = {
+						packets = (xray_settings.fragment_packets and xray_settings.fragment_packets ~= "") and xray_settings.fragment_packets,
+						length = (xray_settings.fragment_length and xray_settings.fragment_length ~= "") and xray_settings.fragment_length,
+						interval = (xray_settings.fragment_interval and xray_settings.fragment_interval ~= "") and xray_settings.fragment_interval
+					}
+				},
+				streamSettings = {
+					sockopt = {
+						mark = 255
+					}
+				}
+			})		
+		end
+		
 		table.insert(outbounds, {
 			protocol = "freedom",
 			tag = "direct",


### PR DESCRIPTION
The aim of this code is to add packet fragmentation functionality  to Passwall2 like in https://github.com/2dust/v2rayNG/commit/c243fadacf60ea8988ea172172f933c07b4574ba .

( Xray Documentation link : https://xtls.github.io/config/outbounds/freedom.html) 

I used [this online tool](https://ircfspace.github.io/fragment/) to generate json client configs and then tried to make similar config in passwall2.  

First two patches add relevant configurations on both OpenWRT and Xray-core sides. However I was out of ideas on How I can  dynamically add `dialerProxy = "fragment"` to desired outbound nodes so I don't need to hardcode it anymore. 