### PR TITLE
Update Auto compile with openwrt sdk.yml

### DIFF
--- a/.github/workflows/Auto compile with openwrt sdk.yml
+++ b/.github/workflows/Auto compile with openwrt sdk.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           cd sdk
           echo "make package/luci-app-passwall2/{clean,compile} -j$(nproc)"
-          make package/luci-app-passwall2/{clean,compile} -j$(nproc)
+          make package/luci-app-passwall2/{clean,compile} -j1
           mv bin/packages/x86_64/passwall2/ ../
           rm .config .config.old
           cd ../passwall2


### PR DESCRIPTION
把多线程编译改为单线程编译，否则无法编译出luci-19.07的安装ipk