### PR TITLE
No longer generates a default routing rule for xray

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -1010,7 +1010,7 @@ function gen_config(var)
 					end
 				end
 			end)
-
+--[[
 			if default_outboundTag or default_balancerTag then
 				table.insert(rules, {
 					_flag = "default",
@@ -1020,7 +1020,7 @@ function gen_config(var)
 					network = "tcp,udp"
 				})
 			end
-
+]]
 			routing = {
 				domainStrategy = node.domainStrategy or "AsIs",
 				domainMatcher = node.domainMatcher or "hybrid",


### PR DESCRIPTION
xray 分流下 Default 只要生成 outbound 放在第一个就够了。
生成路由规则会导致 IPIfNonMatch 下 ip 匹配被跳过，基于ip的规则失效。