### PR TITLE
Iptables: add timeout:3d when create passwall2_global_whitelist ipset

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
@@ -597,8 +597,8 @@ add_firewall_rule() {
 	
 	local ipset_global_whitelist="passwall2_global_whitelist"
 	local ipset_global_whitelist6="passwall2_global_whitelist6"
-	ipset -! create $ipset_global_whitelist nethash maxelem 1048576
-	ipset -! create $ipset_global_whitelist6 nethash family inet6 maxelem 1048576
+	ipset -! create $ipset_global_whitelist nethash maxelem 1048576 timeout 259200
+	ipset -! create $ipset_global_whitelist6 nethash family inet6 maxelem 1048576 timeout 259200
 
 	#  过滤所有节点IP
 	filter_vpsip > /dev/null 2>&1 &

--- a/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
@@ -271,8 +271,8 @@ load_acl() {
 				else
 					local nftset_whitelist="passwall2_${sid}_whitelist"
 					local nftset_whitelist6="passwall2_${sid}_whitelist6"
-					gen_nftset $nftset_whitelist ipv4_addr 0 0
-					gen_nftset $nftset_whitelist6 ipv6_addr 0 0
+					gen_nftset $nftset_whitelist ipv4_addr 3d 3d
+					gen_nftset $nftset_whitelist6 ipv6_addr 3d 3d
 				fi
 			}
 			


### PR DESCRIPTION
对于dns直接缓存的 ip，在 dns 修改或者过期后，我觉得也是需要过期删除的，否则会存在脏数据，影响直连判断

这边设置的默认超时时间为3天，但是3天内有过对应dns解析的ip目前passwall2的表现是会续期超时时间（也就是不会被过期删除），只删除3天内没有dns解析结果的 ip