### PR TITLE
XraySniffing: add wechat c2c to xray domain excluded

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
+++ b/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
@@ -22,4 +22,5 @@ rbsxbxp.vivox.com
 rbspsxp.vivox.com
 rbswxp.vivox.com
 Mijia Cloud
-marscdn.c2c.wechat.com
+dlg.io.mi.com
+regexp:.*\.c2c.wechat\.com$

--- a/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
+++ b/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
@@ -23,4 +23,4 @@ rbspsxp.vivox.com
 rbswxp.vivox.com
 Mijia Cloud
 dlg.io.mi.com
-regexp:.*\.c2c\.wechat\.com$
+marscdn.c2c.wechat.com

--- a/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
+++ b/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
@@ -23,4 +23,4 @@ rbspsxp.vivox.com
 rbswxp.vivox.com
 Mijia Cloud
 dlg.io.mi.com
-regexp:.*\.c2c.wechat\.com$
+regexp:.*\.c2c\.wechat\.com$

--- a/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
+++ b/luci-app-passwall2/root/usr/share/passwall2/domains_excluded
@@ -22,3 +22,4 @@ rbsxbxp.vivox.com
 rbspsxp.vivox.com
 rbswxp.vivox.com
 Mijia Cloud
+marscdn.c2c.wechat.com


### PR DESCRIPTION
看起来前两天更新的IOS最新版微信，加入了marscdn.c2c.wechat.com域名的p2p调用，如果xray开启了流量嗅探并开启覆盖连接目标地址选项后，会出现访问别人朋友没有缓存过的非第一页朋友圈图片无法加载
通过xray日志发现marscdn.c2c.wechat.com这个域名是没有实际 dns 解析配置的，猜测应该是p2p虚拟域名，在排查列表加上这个域名后上述问题就不会出现了
（看看作者觉得是有有必要直接把微信域名后缀全部加入排查重写，用 regexp:.*\.wechat\.com$ 这个排除规则）