### PR TITLE
nonIPQuery blockTypes

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -1238,7 +1238,10 @@ function gen_config(var)
 					address = direct_dns_udp_server,
 					port = tonumber(direct_dns_udp_port) or 53,
 					network = "udp",
-					nonIPQuery = "skip"
+					nonIPQuery = "skip",
+					blockTypes = {
+						65
+					}
 				},
 				proxySettings = {
 					tag = "direct"


### PR DESCRIPTION
XTLS/Xray-core@3fed0c773f2b8af594b3b9016612b8a6919e96bc
xray 24.9.16 dns outbound 引入 blockTypes，不再默认 drop HTTPS 类型的请求，使其在 passwall2 默认配置下被全部转发至直连上游 DNS。