### PR TITLE
Patch 1

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/sing-box.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/sing-box.lua
@@ -408,7 +408,7 @@ if singbox_tags:find("with_ech") then
 	o:depends({ [option_name("protocol")] = "hysteria" })
 	o:depends({ [option_name("protocol")] = "hysteria2" })
 
-	o = s:option(Value, option_name("ech_config"), translate("ECH Config"))
+	o = s:option(DynamicList, option_name("ech_config"), translate("ECH Config"))
 	o.default = ""
 	o:depends({ [option_name("ech")] = true })
 

--- a/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
@@ -97,7 +97,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 				--max_version = "1.3",
 				ech = {
 					enabled = (node.ech == "1") and true or false,
-					config = (node.ech_config and node.ech_config:gsub("\\n","\n")) and node.ech_config:gsub("\\n","\n") or nil,
+					config = node.ech_config or {},
 					pq_signature_schemes_enabled = node.pq_signature_schemes_enabled and true or false,
 					dynamic_record_sizing_disabled = node.dynamic_record_sizing_disabled and true or false
 				},
@@ -307,7 +307,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 					} or nil,
 					ech = {
 						enabled = (node.ech == "1") and true or false,
-						config = (node.ech_config and node.ech_config:gsub("\\n","\n")) and node.ech_config:gsub("\\n","\n") or nil,
+						config = node.ech_config or {},
 						pq_signature_schemes_enabled = node.pq_signature_schemes_enabled and true or false,
 						dynamic_record_sizing_disabled = node.dynamic_record_sizing_disabled and true or false
 					}
@@ -341,7 +341,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 					} or nil,
 					ech = {
 						enabled = (node.ech == "1") and true or false,
-						config = (node.ech_config and node.ech_config:gsub("\\n","\n")) and node.ech_config:gsub("\\n","\n") or nil,
+						config = node.ech_config or {},
 						pq_signature_schemes_enabled = node.pq_signature_schemes_enabled and true or false,
 						dynamic_record_sizing_disabled = node.dynamic_record_sizing_disabled and true or false
 					}
@@ -364,7 +364,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 					insecure = (node.tls_allowInsecure == "1") and true or false,
 					ech = {
 						enabled = (node.ech == "1") and true or false,
-						config = (node.ech_config and node.ech_config:gsub("\\n","\n")) and node.ech_config:gsub("\\n","\n") or nil,
+						config = node.ech_config or {},
 						pq_signature_schemes_enabled = node.pq_signature_schemes_enabled and true or false,
 						dynamic_record_sizing_disabled = node.dynamic_record_sizing_disabled and true or false
 					}


### PR DESCRIPTION
ech_config option is line array, in PEM format[1]

```bash
root@OpenWrt:~# cat /var/etc/passwall2/acl/default/global.json
config nodes 'Remarks'
	option remarks 'Remarks'
	option type 'sing-box'
	option protocol 'hysteria2'
	option address '151515151'
	option port '11'
	option ech '1'
	list ech_config '----BEGIN ECH CONFIGS---'
	list ech_config 'DSxzn+DJk9efhs'
	list ech_config 'FSKJFSKJSFEJFSSDJ='
	list ech_config '---END ECH CONFIG----'
root@OpenWrt:~# cat /var/etc/passwall2/acl/default/global.json
        "ech": {
          "enabled": true,
          "config": [
            "---BEGIN ECH CONFIGS---",
            "DSxzn+DJk9efhs",
            "FSKJFSKJSFEJFSSDJ=",
            "----END ECH CONFIG----"
          ],


```


https://sing-box.sagernet.org/configuration/shared/tls/#config