### PR TITLE
luci: default preproxy fix

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -866,7 +866,11 @@ function gen_config(var)
 							local outbound = gen_outbound(flag, _node, rule_name, proxy_table)
 							if outbound then
 								set_outbound_detour(_node, outbound, outbounds, rule_name)
-								table.insert(outbounds, outbound)
+								if rule_name == "default" then
+									table.insert(outbounds, 1, outbound)
+								else
+									table.insert(outbounds, outbound)
+								end
 								rule_outboundTag = rule_name
 							end
 						end


### PR DESCRIPTION
https://github.com/xiaorouji/openwrt-passwall2/pull/640#issuecomment-2400244910
存在 preproxy (main) 且路由无匹配时出站不正确，default 应始终在第一个。