### PR TITLE
luci: fix xray SniffingObject generate

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
@@ -166,7 +166,7 @@ if has_xray then
 
 	o = s_xray:option(Flag, "sniffing_override_dest", translate("Override the connection destination address"))
 	o.default = 0
-	o.description = translate("Override the connection destination address with the sniffed domain.<br />When enabled, traffic will match only by domain, ignoring IP rules.<br />If using shunt nodes, configure the domain shunt rules correctly.")
+	o.description = translate("Override the connection destination address with the sniffed domain.<br />Otherwise use sniffed domain for routing only.<br />If using shunt nodes, configure the domain shunt rules correctly.")
 
 	o = s_xray:option(Flag, "route_only", translate("Sniffing Route Only"))
 	o.default = 0

--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -612,8 +612,15 @@ function gen_config(var)
 			port = tonumber(local_socks_port),
 			protocol = "socks",
 			settings = {auth = "noauth", udp = true},
-			sniffing = {enabled = true, destOverride = {"http", "tls", "quic"}}
+			sniffing = {
+				enabled = xray_settings.sniffing_override_dest == "1" or node.protocol == "_shunt"
+			}
 		}
+		if inbound.sniffing.enabled == true then
+			inbound.sniffing.destOverride = {"http", "tls", "quic"}
+			inbound.sniffing.routeOnly = xray_settings.sniffing_override_dest ~= "1" or nil
+			inbound.sniffing.domainsExcluded = xray_settings.sniffing_override_dest == "1" and get_domain_excluded() or nil
+		end
 		if local_socks_username and local_socks_password and local_socks_username ~= "" and local_socks_password ~= "" then
 			inbound.settings.auth = "password"
 			inbound.settings.accounts = {
@@ -651,13 +658,16 @@ function gen_config(var)
 			settings = {network = "tcp,udp", followRedirect = true},
 			streamSettings = {sockopt = {tproxy = "tproxy"}},
 			sniffing = {
-				enabled = xray_settings.sniffing_override_dest == "1" or node.protocol == "_shunt",
-				destOverride = {"http", "tls", "quic", (remote_dns_fake) and "fakedns"},
-				metadataOnly = false,
-				routeOnly = node.protocol == "_shunt" and xray_settings.sniffing_override_dest ~= "1" or nil,
-				domainsExcluded = xray_settings.sniffing_override_dest == "1" and get_domain_excluded() or nil
+				enabled = xray_settings.sniffing_override_dest == "1" or node.protocol == "_shunt"
 			}
 		}
+		if inbound.sniffing.enabled == true then
+			inbound.sniffing.destOverride = {"http", "tls", "quic", (remote_dns_fake) and "fakedns"}
+			inbound.sniffing.metadataOnly = false
+			inbound.sniffing.routeOnly = xray_settings.sniffing_override_dest ~= "1" or nil
+			inbound.sniffing.domainsExcluded = xray_settings.sniffing_override_dest == "1" and get_domain_excluded() or nil
+		end
+
 		local tcp_inbound = api.clone(inbound)
 		tcp_inbound.tag = "tcp_redir"
 		tcp_inbound.settings.network = "tcp"

--- a/luci-app-passwall2/po/zh-cn/passwall2.po
+++ b/luci-app-passwall2/po/zh-cn/passwall2.po
@@ -1486,6 +1486,9 @@ msgstr "Sing-Box 会在启动时自动下载资源文件，您可以使用此功
 msgid "Override the connection destination address"
 msgstr "覆盖连接目标地址"
 
+msgid "Override the connection destination address with the sniffed domain.<br />Otherwise use sniffed domain for routing only.<br />If using shunt nodes, configure the domain shunt rules correctly."
+msgstr "用探测出的域名覆盖连接目标地址。<br />否则仅将探测得到的域名用于路由。<br />如使用分流节点，请正确设置域名分流规则。"
+
 msgid "Override the connection destination address with the sniffed domain.<br />When enabled, traffic will match only by domain, ignoring IP rules.<br />If using shunt nodes, configure the domain shunt rules correctly."
 msgstr "用探测出的域名覆盖连接目标地址。<br />启用后仅使用域名进行流量匹配，将忽略IP规则。<br />如使用分流节点，请正确设置域名分流规则。"
 


### PR DESCRIPTION
对于 Xray：
- 路由匹配策略服从用户分流节点的设置，与重写目标地址与否没有关联，描述有误；
- 是否重写目标地址不需要考虑是否分流，应完全服从用户设置；
- socks 入站（特别是 haproxy）的嗅探同样应该服从用户设置。
目前 haproxy 入站强制嗅探并重写域名，导致在远端会多解析一次。