### PR TITLE
luci: add XUDP Mux option for shadowsocks node

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/ray.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/ray.lua
@@ -631,6 +631,7 @@ o = s:option(Flag, _n("xmux"), "XUDP Mux")
 o.default = 1
 o:depends({ [_n("protocol")] = "vless", [_n("flow")] = "xtls-rprx-vision" })
 o:depends({ [_n("protocol")] = "vless", [_n("flow")] = "xtls-rprx-vision-udp443" })
+o:depends({ [_n("protocol")] = "shadowsocks" })
 
 o = s:option(Value, _n("xudp_concurrency"), translate("XUDP Mux concurrency"))
 o.default = 8


### PR DESCRIPTION
Make XUDP Mux option avaliable for shadowsocks in Xray